### PR TITLE
trace exact timestamps

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -78,7 +78,7 @@ func (t *trace) push(evt traceEvt) {
 	if t.done {
 		return
 	}
-	evt.Time = time.Now().Format(time.RFC3339)
+	evt.Time = time.Now().Format(time.RFC3339Nano)
 
 	t.pend = append(t.pend, evt)
 }


### PR DESCRIPTION
RFC3339 only exports up to second granularity, which is not enough for a detailed analysis.