### PR TITLE
include current limits in debug messages

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,81 @@
+package rcmgr
+
+import (
+	"errors"
+
+	"github.com/libp2p/go-libp2p-core/network"
+)
+
+type errStreamOrConnLimitExceeded struct {
+	current, attempted, limit int
+	err                       error
+}
+
+func (e *errStreamOrConnLimitExceeded) Error() string { return e.err.Error() }
+func (e *errStreamOrConnLimitExceeded) Unwrap() error { return e.err }
+
+// edge may be "" if this is not an edge error
+func logValuesStreamLimit(scope, edge string, dir network.Direction, stat network.ScopeStat, err error) []interface{} {
+	logValues := make([]interface{}, 0, 2*8)
+	logValues = append(logValues, "scope", scope)
+	if edge != "" {
+		logValues = append(logValues, "edge", edge)
+	}
+	logValues = append(logValues, "direction", dir)
+	var e *errStreamOrConnLimitExceeded
+	if errors.As(err, &e) {
+		logValues = append(logValues,
+			"current", e.current,
+			"attempted", e.attempted,
+			"limit", e.limit,
+		)
+	}
+	return append(logValues, "stat", stat, "error", err)
+}
+
+// edge may be "" if this is not an edge error
+func logValuesConnLimit(scope, edge string, dir network.Direction, usefd bool, stat network.ScopeStat, err error) []interface{} {
+	logValues := make([]interface{}, 0, 2*9)
+	logValues = append(logValues, "scope", scope)
+	if edge != "" {
+		logValues = append(logValues, "edge", edge)
+	}
+	logValues = append(logValues, "direction", dir, "usefd", usefd)
+	var e *errStreamOrConnLimitExceeded
+	if errors.As(err, &e) {
+		logValues = append(logValues,
+			"current", e.current,
+			"attempted", e.attempted,
+			"limit", e.limit,
+		)
+	}
+	return append(logValues, "stat", stat, "error", err)
+}
+
+type errMemoryLimitExceeded struct {
+	current, attempted, limit int64
+	priority                  uint8
+	err                       error
+}
+
+func (e *errMemoryLimitExceeded) Error() string { return e.err.Error() }
+func (e *errMemoryLimitExceeded) Unwrap() error { return e.err }
+
+// edge may be "" if this is not an edge error
+func logValuesMemoryLimit(scope, edge string, stat network.ScopeStat, err error) []interface{} {
+	logValues := make([]interface{}, 0, 2*8)
+	logValues = append(logValues, "scope", scope)
+	if edge != "" {
+		logValues = append(logValues, "edge", edge)
+	}
+	var e *errMemoryLimitExceeded
+	if errors.As(err, &e) {
+		logValues = append(logValues,
+			"current", e.current,
+			"attempted", e.attempted,
+			"priority", e.priority,
+			"limit", e.limit,
+		)
+	}
+	return append(logValues, "stat", stat, "error", err)
+}

--- a/scope.go
+++ b/scope.go
@@ -34,6 +34,23 @@ func (e *errStreamOrConnLimitExceeded) AppendLogValues(v []interface{}) []interf
 	)
 }
 
+type errMemoryLimitExceeded struct {
+	current, attempted, limit int64
+	priority                  uint8
+	err                       error
+}
+
+func (e *errMemoryLimitExceeded) Error() string { return e.err.Error() }
+func (e *errMemoryLimitExceeded) Unwrap() error { return e.err }
+func (e *errMemoryLimitExceeded) AppendLogValues(v []interface{}) []interface{} {
+	return append(v,
+		"current", e.current,
+		"attempted", e.attempted,
+		"priority", e.priority,
+		"limit", e.limit,
+	)
+}
+
 // A resourceScope can be a DAG, where a downstream node is not allowed to outlive an upstream node
 // (ie cannot call Done in the upstream node before the downstream node) and account for resources
 // using a linearized parent set.
@@ -95,9 +112,14 @@ func (rc *resources) checkMemory(rsvp int64, prio uint8) error {
 	threshold := (1 + int64(prio)) * limit / 256
 
 	if newmem > threshold {
-		return network.ErrResourceLimitExceeded
+		return &errMemoryLimitExceeded{
+			current:   rc.memory,
+			attempted: rsvp,
+			limit:     limit,
+			priority:  prio,
+			err:       network.ErrResourceLimitExceeded,
+		}
 	}
-
 	return nil
 }
 
@@ -307,7 +329,14 @@ func (s *resourceScope) ReserveMemory(size int, prio uint8) error {
 	}
 
 	if err := s.rc.reserveMemory(int64(size), prio); err != nil {
-		log.Debugw("blocked memory reservation", "scope", s.name, "size", size, "priority", prio, "stat", s.rc.stat(), "error", err)
+		logValues := make([]interface{}, 0, 6)
+		logValues = append(logValues, "scope", s.name)
+		var limitErr *errMemoryLimitExceeded
+		if errors.As(err, &limitErr) {
+			logValues = limitErr.AppendLogValues(logValues)
+		}
+		logValues = append(logValues, "error", err)
+		log.Debugw("blocked memory reservation", logValues...)
 		s.trace.BlockReserveMemory(s.name, prio, int64(size), s.rc.memory)
 		s.metrics.BlockMemory(size)
 		return s.wrapError(err)
@@ -333,7 +362,14 @@ func (s *resourceScope) reserveMemoryForEdges(size int, prio uint8) error {
 	var err error
 	for _, e := range s.edges {
 		if err = e.ReserveMemoryForChild(int64(size), prio); err != nil {
-			log.Debugw("blocked memory reservation from constraining edge", "scope", s.name, "edge", e.name, "size", size, "priority", prio, "stat", e.Stat(), "error", err)
+			logValues := make([]interface{}, 0, 6)
+			logValues = append(logValues, "scope", s.name, "edge", e.name)
+			var limitErr *errMemoryLimitExceeded
+			if errors.As(err, &limitErr) {
+				logValues = limitErr.AppendLogValues(logValues)
+			}
+			logValues = append(logValues, "error", err)
+			log.Debugw("blocked memory reservation from constraining edge", logValues...)
 			break
 		}
 

--- a/scope.go
+++ b/scope.go
@@ -1,7 +1,6 @@
 package rcmgr
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -17,80 +16,6 @@ type resources struct {
 	nfd                     int
 
 	memory int64
-}
-
-type errStreamOrConnLimitExceeded struct {
-	current, attempted, limit int
-	err                       error
-}
-
-func (e *errStreamOrConnLimitExceeded) Error() string { return e.err.Error() }
-func (e *errStreamOrConnLimitExceeded) Unwrap() error { return e.err }
-
-// edge may be "" if this is not an edge error
-func logValuesStreamLimit(scope, edge string, dir network.Direction, stat network.ScopeStat, err error) []interface{} {
-	logValues := make([]interface{}, 0, 2*8)
-	logValues = append(logValues, "scope", scope)
-	if edge != "" {
-		logValues = append(logValues, "edge", edge)
-	}
-	logValues = append(logValues, "direction", dir)
-	var e *errStreamOrConnLimitExceeded
-	if errors.As(err, &e) {
-		logValues = append(logValues,
-			"current", e.current,
-			"attempted", e.attempted,
-			"limit", e.limit,
-		)
-	}
-	return append(logValues, "stat", stat, "error", err)
-}
-
-// edge may be "" if this is not an edge error
-func logValuesConnLimit(scope, edge string, dir network.Direction, usefd bool, stat network.ScopeStat, err error) []interface{} {
-	logValues := make([]interface{}, 0, 2*9)
-	logValues = append(logValues, "scope", scope)
-	if edge != "" {
-		logValues = append(logValues, "edge", edge)
-	}
-	logValues = append(logValues, "direction", dir, "usefd", usefd)
-	var e *errStreamOrConnLimitExceeded
-	if errors.As(err, &e) {
-		logValues = append(logValues,
-			"current", e.current,
-			"attempted", e.attempted,
-			"limit", e.limit,
-		)
-	}
-	return append(logValues, "stat", stat, "error", err)
-}
-
-type errMemoryLimitExceeded struct {
-	current, attempted, limit int64
-	priority                  uint8
-	err                       error
-}
-
-func (e *errMemoryLimitExceeded) Error() string { return e.err.Error() }
-func (e *errMemoryLimitExceeded) Unwrap() error { return e.err }
-
-// edge may be "" if this is not an edge error
-func logValuesMemoryLimit(scope, edge string, stat network.ScopeStat, err error) []interface{} {
-	logValues := make([]interface{}, 0, 2*8)
-	logValues = append(logValues, "scope", scope)
-	if edge != "" {
-		logValues = append(logValues, "edge", edge)
-	}
-	var e *errMemoryLimitExceeded
-	if errors.As(err, &e) {
-		logValues = append(logValues,
-			"current", e.current,
-			"attempted", e.attempted,
-			"priority", e.priority,
-			"limit", e.limit,
-		)
-	}
-	return append(logValues, "stat", stat, "error", err)
 }
 
 // A resourceScope can be a DAG, where a downstream node is not allowed to outlive an upstream node

--- a/scope.go
+++ b/scope.go
@@ -19,14 +19,14 @@ type resources struct {
 	memory int64
 }
 
-type errStreamLimitExceeded struct {
+type errStreamOrConnLimitExceeded struct {
 	current, attempted, limit int
 	err                       error
 }
 
-func (e *errStreamLimitExceeded) Error() string { return e.err.Error() }
-func (e *errStreamLimitExceeded) Unwrap() error { return e.err }
-func (e *errStreamLimitExceeded) AppendLogValues(v []interface{}) []interface{} {
+func (e *errStreamOrConnLimitExceeded) Error() string { return e.err.Error() }
+func (e *errStreamOrConnLimitExceeded) Unwrap() error { return e.err }
+func (e *errStreamOrConnLimitExceeded) AppendLogValues(v []interface{}) []interface{} {
 	return append(v,
 		"current", e.current,
 		"attempted", e.attempted,
@@ -131,7 +131,7 @@ func (rc *resources) addStreams(incount, outcount int) error {
 	if incount > 0 {
 		limit := rc.limit.GetStreamLimit(network.DirInbound)
 		if rc.nstreamsIn+incount > limit {
-			return &errStreamLimitExceeded{
+			return &errStreamOrConnLimitExceeded{
 				current:   rc.nstreamsIn,
 				attempted: incount,
 				limit:     limit,
@@ -142,7 +142,7 @@ func (rc *resources) addStreams(incount, outcount int) error {
 	if outcount > 0 {
 		limit := rc.limit.GetStreamLimit(network.DirOutbound)
 		if rc.nstreamsOut+outcount > limit {
-			return &errStreamLimitExceeded{
+			return &errStreamOrConnLimitExceeded{
 				current:   rc.nstreamsOut,
 				attempted: outcount,
 				limit:     limit,
@@ -152,7 +152,7 @@ func (rc *resources) addStreams(incount, outcount int) error {
 	}
 
 	if limit := rc.limit.GetStreamTotalLimit(); rc.nstreamsIn+incount+rc.nstreamsOut+outcount > limit {
-		return &errStreamLimitExceeded{
+		return &errStreamOrConnLimitExceeded{
 			current:   rc.nstreamsIn + rc.nstreamsOut,
 			attempted: incount + outcount,
 			limit:     limit,
@@ -201,17 +201,47 @@ func (rc *resources) addConn(dir network.Direction, usefd bool) error {
 }
 
 func (rc *resources) addConns(incount, outcount, fdcount int) error {
-	if incount > 0 && rc.nconnsIn+incount > rc.limit.GetConnLimit(network.DirInbound) {
-		return fmt.Errorf("cannot reserve connection: %w", network.ErrResourceLimitExceeded)
+	if incount > 0 {
+		limit := rc.limit.GetConnLimit(network.DirInbound)
+		if rc.nconnsIn+incount > limit {
+			return &errStreamOrConnLimitExceeded{
+				current:   rc.nconnsIn,
+				attempted: incount,
+				limit:     limit,
+				err:       fmt.Errorf("cannot reserve inbound connection: %w", network.ErrResourceLimitExceeded),
+			}
+		}
 	}
-	if outcount > 0 && rc.nconnsOut+outcount > rc.limit.GetConnLimit(network.DirOutbound) {
-		return fmt.Errorf("cannot reserve connection: %w", network.ErrResourceLimitExceeded)
+	if outcount > 0 {
+		limit := rc.limit.GetConnLimit(network.DirOutbound)
+		if rc.nconnsOut+outcount > limit {
+			return &errStreamOrConnLimitExceeded{
+				current:   rc.nconnsOut,
+				attempted: outcount,
+				limit:     limit,
+				err:       fmt.Errorf("cannot reserve outbound connection: %w", network.ErrResourceLimitExceeded),
+			}
+		}
 	}
-	if rc.nconnsIn+incount+rc.nconnsOut+outcount > rc.limit.GetConnTotalLimit() {
-		return fmt.Errorf("cannot reserve connection: %w", network.ErrResourceLimitExceeded)
+
+	if connLimit := rc.limit.GetConnTotalLimit(); rc.nconnsIn+incount+rc.nconnsOut+outcount > connLimit {
+		return &errStreamOrConnLimitExceeded{
+			current:   rc.nconnsIn + rc.nconnsOut,
+			attempted: incount + outcount,
+			limit:     connLimit,
+			err:       fmt.Errorf("cannot reserve connection: %w", network.ErrResourceLimitExceeded),
+		}
 	}
-	if fdcount > 0 && rc.nfd+fdcount > rc.limit.GetFDLimit() {
-		return fmt.Errorf("cannot reserve file descriptor: %w", network.ErrResourceLimitExceeded)
+	if fdcount > 0 {
+		limit := rc.limit.GetFDLimit()
+		if rc.nfd+fdcount > limit {
+			return &errStreamOrConnLimitExceeded{
+				current:   rc.nfd,
+				attempted: fdcount,
+				limit:     limit,
+				err:       fmt.Errorf("cannot reserve file descriptor: %w", network.ErrResourceLimitExceeded),
+			}
+		}
 	}
 
 	rc.nconnsIn += incount
@@ -384,7 +414,7 @@ func (s *resourceScope) AddStream(dir network.Direction) error {
 	if err := s.rc.addStream(dir); err != nil {
 		logValues := make([]interface{}, 0, 6)
 		logValues = append(logValues, "scope", s.name, "direction", dir)
-		var limitErr *errStreamLimitExceeded
+		var limitErr *errStreamOrConnLimitExceeded
 		if errors.As(err, &limitErr) {
 			logValues = limitErr.AppendLogValues(logValues)
 		}
@@ -414,7 +444,7 @@ func (s *resourceScope) addStreamForEdges(dir network.Direction) error {
 		if err = e.AddStreamForChild(dir); err != nil {
 			logValues := make([]interface{}, 0, 7)
 			logValues = append(logValues, "scope", s.name, "edge", e.name, "direction", dir)
-			var limitErr *errStreamLimitExceeded
+			var limitErr *errStreamOrConnLimitExceeded
 			if errors.As(err, &limitErr) {
 				logValues = limitErr.AppendLogValues(logValues)
 			}
@@ -496,7 +526,14 @@ func (s *resourceScope) AddConn(dir network.Direction, usefd bool) error {
 	}
 
 	if err := s.rc.addConn(dir, usefd); err != nil {
-		log.Debugw("blocked connection", "scope", s.name, "direction", dir, "usefd", usefd, "stat", s.rc.stat(), "error", err)
+		logValues := make([]interface{}, 0, 7)
+		logValues = append(logValues, "scope", s.name, "direction", dir, "usefd", usefd)
+		var limitErr *errStreamOrConnLimitExceeded
+		if errors.As(err, &limitErr) {
+			logValues = limitErr.AppendLogValues(logValues)
+		}
+		logValues = append(logValues, "error", err)
+		log.Debugw("blocked connection", logValues...)
 		s.trace.BlockAddConn(s.name, dir, usefd, s.rc.nconnsIn, s.rc.nconnsOut, s.rc.nfd)
 		return s.wrapError(err)
 	}
@@ -519,7 +556,14 @@ func (s *resourceScope) addConnForEdges(dir network.Direction, usefd bool) error
 	var reserved int
 	for _, e := range s.edges {
 		if err = e.AddConnForChild(dir, usefd); err != nil {
-			log.Debugw("blocked connection from constraining edge", "scope", s.name, "edge", e.name, "direction", dir, "usefd", usefd, "stat", e.Stat(), "error", err)
+			logValues := make([]interface{}, 0, 7)
+			logValues = append(logValues, "scope", s.name, "edge", e.name, "direction", dir, "usefd", usefd)
+			var limitErr *errStreamOrConnLimitExceeded
+			if errors.As(err, &limitErr) {
+				logValues = limitErr.AppendLogValues(logValues)
+			}
+			logValues = append(logValues, "error", err)
+			log.Debugw("blocked connection from constraining edge", logValues...)
 			break
 		}
 		reserved++

--- a/scope.go
+++ b/scope.go
@@ -1,6 +1,7 @@
 package rcmgr
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -16,6 +17,21 @@ type resources struct {
 	nfd                     int
 
 	memory int64
+}
+
+type errStreamLimitExceeded struct {
+	current, attempted, limit int
+	err                       error
+}
+
+func (e *errStreamLimitExceeded) Error() string { return e.err.Error() }
+func (e *errStreamLimitExceeded) Unwrap() error { return e.err }
+func (e *errStreamLimitExceeded) AppendLogValues(v []interface{}) []interface{} {
+	return append(v,
+		"current", e.current,
+		"attempted", e.attempted,
+		"limit", e.limit,
+	)
 }
 
 // A resourceScope can be a DAG, where a downstream node is not allowed to outlive an upstream node
@@ -112,14 +128,36 @@ func (rc *resources) addStream(dir network.Direction) error {
 }
 
 func (rc *resources) addStreams(incount, outcount int) error {
-	if incount > 0 && rc.nstreamsIn+incount > rc.limit.GetStreamLimit(network.DirInbound) {
-		return fmt.Errorf("cannot reserve stream: %w", network.ErrResourceLimitExceeded)
+	if incount > 0 {
+		limit := rc.limit.GetStreamLimit(network.DirInbound)
+		if rc.nstreamsIn+incount > limit {
+			return &errStreamLimitExceeded{
+				current:   rc.nstreamsIn,
+				attempted: incount,
+				limit:     limit,
+				err:       fmt.Errorf("cannot reserve inbound stream: %w", network.ErrResourceLimitExceeded),
+			}
+		}
 	}
-	if outcount > 0 && rc.nstreamsOut+outcount > rc.limit.GetStreamLimit(network.DirOutbound) {
-		return fmt.Errorf("cannot reserve stream: %w", network.ErrResourceLimitExceeded)
+	if outcount > 0 {
+		limit := rc.limit.GetStreamLimit(network.DirOutbound)
+		if rc.nstreamsOut+outcount > limit {
+			return &errStreamLimitExceeded{
+				current:   rc.nstreamsOut,
+				attempted: outcount,
+				limit:     limit,
+				err:       fmt.Errorf("cannot reserve outbound stream: %w", network.ErrResourceLimitExceeded),
+			}
+		}
 	}
-	if rc.nstreamsIn+incount+rc.nstreamsOut+outcount > rc.limit.GetStreamTotalLimit() {
-		return fmt.Errorf("cannot reserve stream: %w", network.ErrResourceLimitExceeded)
+
+	if limit := rc.limit.GetStreamTotalLimit(); rc.nstreamsIn+incount+rc.nstreamsOut+outcount > limit {
+		return &errStreamLimitExceeded{
+			current:   rc.nstreamsIn + rc.nstreamsOut,
+			attempted: incount + outcount,
+			limit:     limit,
+			err:       fmt.Errorf("cannot reserve stream: %w", network.ErrResourceLimitExceeded),
+		}
 	}
 
 	rc.nstreamsIn += incount
@@ -344,7 +382,14 @@ func (s *resourceScope) AddStream(dir network.Direction) error {
 	}
 
 	if err := s.rc.addStream(dir); err != nil {
-		log.Debugw("blocked stream", "scope", s.name, "direction", dir, "stat", s.rc.stat(), "error", err)
+		logValues := make([]interface{}, 0, 6)
+		logValues = append(logValues, "scope", s.name, "direction", dir)
+		var limitErr *errStreamLimitExceeded
+		if errors.As(err, &limitErr) {
+			logValues = limitErr.AppendLogValues(logValues)
+		}
+		logValues = append(logValues, "error", err)
+		log.Debugw("blocked stream", logValues...)
 		s.trace.BlockAddStream(s.name, dir, s.rc.nstreamsIn, s.rc.nstreamsOut)
 		return s.wrapError(err)
 	}
@@ -367,7 +412,14 @@ func (s *resourceScope) addStreamForEdges(dir network.Direction) error {
 	var reserved int
 	for _, e := range s.edges {
 		if err = e.AddStreamForChild(dir); err != nil {
-			log.Debugw("blocked stream from constraining edge", "scope", s.name, "edge", e.name, "direction", dir, "stat", e.Stat(), "error", err)
+			logValues := make([]interface{}, 0, 7)
+			logValues = append(logValues, "scope", s.name, "edge", e.name, "direction", dir)
+			var limitErr *errStreamLimitExceeded
+			if errors.As(err, &limitErr) {
+				logValues = limitErr.AppendLogValues(logValues)
+			}
+			logValues = append(logValues, "error", err)
+			log.Debugw("blocked stream from constraining edge", logValues...)
 			break
 		}
 		reserved++


### PR DESCRIPTION
Fixes #26.

Potentially controversial: also removes the `stat` from the debug output, to focus on the thing that is actually getting blocked. We can add it back if preferred.