### PR TITLE
Add ability to configure allowlist limits

### DIFF
--- a/limit.go
+++ b/limit.go
@@ -29,6 +29,8 @@ type Limit interface {
 type Limiter interface {
 	GetSystemLimits() Limit
 	GetTransientLimits() Limit
+	GetAllowlistedSystemLimits() Limit
+	GetAllowlistedTransientLimits() Limit
 	GetServiceLimits(svc string) Limit
 	GetServicePeerLimits(svc string) Limit
 	GetProtocolLimits(proto protocol.ID) Limit
@@ -194,6 +196,14 @@ func (l *fixedLimiter) GetSystemLimits() Limit {
 
 func (l *fixedLimiter) GetTransientLimits() Limit {
 	return &l.Transient
+}
+
+func (l *fixedLimiter) GetAllowlistedSystemLimits() Limit {
+	return &l.AllowlistedSystem
+}
+
+func (l *fixedLimiter) GetAllowlistedTransientLimits() Limit {
+	return &l.AllowlistedTransient
 }
 
 func (l *fixedLimiter) GetServiceLimits(svc string) Limit {

--- a/limit_defaults.go
+++ b/limit_defaults.go
@@ -366,7 +366,7 @@ var DefaultLimits = ScalingLimitConfig{
 	// allowlist only activates when you reach your normal system/transient
 	// limits. So it's okay if these limits err on the side of being too big,
 	// since most of the time you won't even use any of these. Tune these down
-	// if you want to manager your resources against an allowlisted endpoint.
+	// if you want to manage your resources against an allowlisted endpoint.
 	AllowlistedSystemBaseLimit: BaseLimit{
 		ConnsInbound:    64,
 		ConnsOutbound:   128,

--- a/limit_test.go
+++ b/limit_test.go
@@ -13,7 +13,7 @@ func TestFileDescriptorCounting(t *testing.T) {
 	}
 	n := getNumFDs()
 	require.NotZero(t, n)
-	require.Less(t, n, int(1e6))
+	require.Less(t, n, int(1e7))
 }
 
 func TestScaling(t *testing.T) {

--- a/rcmgr.go
+++ b/rcmgr.go
@@ -150,9 +150,9 @@ func NewResourceManager(limits Limiter, opts ...Option) (network.ResourceManager
 	r.transient = newTransientScope(limits.GetTransientLimits(), r, "transient", r.system.resourceScope)
 	r.transient.IncRef()
 
-	r.allowlistedSystem = newSystemScope(limits.GetSystemLimits(), r, "allowlistedSystem")
+	r.allowlistedSystem = newSystemScope(limits.GetAllowlistedSystemLimits(), r, "allowlistedSystem")
 	r.allowlistedSystem.IncRef()
-	r.allowlistedTransient = newTransientScope(limits.GetTransientLimits(), r, "allowlistedTransient", r.allowlistedSystem.resourceScope)
+	r.allowlistedTransient = newTransientScope(limits.GetAllowlistedTransientLimits(), r, "allowlistedTransient", r.allowlistedSystem.resourceScope)
 	r.allowlistedTransient.IncRef()
 
 	r.cancelCtx, r.cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
Extends on #48 to allow configuring the limits for the allowlist. By default they are the same as the system limits.

Also remember that the allowlist isn't hit unless the system/transient have reached their limits.


Only the commits after 1d67ac4e20cb1ec41e6f3543494bebed64cc908a should be reviewed. The rest are from #48 or a merge commit.

Before merge:
- [x] Merge #48
- [x] Rebase this