### PR TITLE
don't limit the number of FDs on Windows when autoscaling

### DIFF
--- a/sys_not_unix.go
+++ b/sys_not_unix.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package rcmgr
 

--- a/sys_windows.go
+++ b/sys_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package rcmgr
+
+import (
+	"math"
+)
+
+func getNumFDs() int {
+	return math.MaxInt
+}


### PR DESCRIPTION
Apparently Windows doesn't limit the number of file descriptors as Linux does. Therefore there's also no way to get the current limit.