### PR TITLE
Don't wait for a chan that will never close

### DIFF
--- a/obs/stats_test.go
+++ b/obs/stats_test.go
@@ -1,0 +1,16 @@
+package obs_test
+
+import (
+	"testing"
+
+	rcmgr "github.com/libp2p/go-libp2p-resource-manager"
+	"github.com/libp2p/go-libp2p-resource-manager/obs"
+)
+
+func TestTraceReporterStartAndClose(t *testing.T) {
+	rcmgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(rcmgr.DefaultLimits.AutoScale()), rcmgr.WithTraceReporter(obs.StatsTraceReporter{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rcmgr.Close()
+}

--- a/rcmgr_test.go
+++ b/rcmgr_test.go
@@ -1004,6 +1004,7 @@ func TestResourceManagerWithAllowlist(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rcmgr.Close()
 
 	ableToGetAllowlist := GetAllowlist(rcmgr)
 	if ableToGetAllowlist == nil {


### PR DESCRIPTION
Fixes a subtle bug where we assumed we would always have a background task when we have a trace object. This would cause `trace.Close()` to hang indefinitely.

The fix is to use a waitgroup instead of a semaphore channel. Then we add to the waitgroup when we spawn a background task.
