### PR TITLE
Implement `json.Marshaler` interface for LimitConfig

### DIFF
--- a/limit_config_test.go
+++ b/limit_config_test.go
@@ -1,6 +1,8 @@
 package rcmgr
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -50,4 +52,11 @@ func TestLimitConfigParser(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, cfg.Peer, peerID)
 	require.Equal(t, int64(4097), cfg.Peer[peerID].Memory)
+
+	// Roundtrip
+	jsonBytes, err := json.Marshal(&cfg)
+	require.NoError(t, err)
+	cfgAfterRoundTrip, err := readLimiterConfigFromJSON(bytes.NewReader(jsonBytes), defaults)
+	require.NoError(t, err)
+	require.Equal(t, cfg, cfgAfterRoundTrip)
 }

--- a/limit_defaults.go
+++ b/limit_defaults.go
@@ -1,6 +1,7 @@
 package rcmgr
 
 import (
+	"encoding/json"
 	"math"
 
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -134,6 +135,23 @@ type LimitConfig struct {
 
 	Conn   BaseLimit `json:",omitempty"`
 	Stream BaseLimit `json:",omitempty"`
+}
+
+func (cfg *LimitConfig) MarshalJSON() ([]byte, error) {
+	// we want to marshal the encoded peer id
+	encodedPeerMap := make(map[string]BaseLimit, len(cfg.Peer))
+	for p, v := range cfg.Peer {
+		encodedPeerMap[peer.Encode(p)] = v
+	}
+
+	type Alias LimitConfig
+	return json.Marshal(&struct {
+		*Alias
+		Peer map[string]BaseLimit `json:",omitempty"`
+	}{
+		Alias: (*Alias)(cfg),
+		Peer:  encodedPeerMap,
+	})
 }
 
 func (cfg *LimitConfig) Apply(c LimitConfig) {


### PR DESCRIPTION
Fixes a bug where we would output the json with the raw peer id rather than the encoded version. This would mean would aren't able to round trip serialize the config. e.g. take the config, write it json, read it from json and compare it with the original config.

This uses the type alias marshaling trick. More can info about this can be found at https://calvinfeng.gitbook.io/gonotebook/idioms/custom-json-marshaling#better-approach (and many other sources).

