### PR TITLE
Fix usage of make to reserve capacity, not values

### DIFF
--- a/obs/stats.go
+++ b/obs/stats.go
@@ -322,14 +322,14 @@ func (r StatsTraceReporter) ConsumeEvent(evt rcmgr.TraceEvt) {
 		tags := []tag.Mutator{tag.Upsert(scopeTag, scopeName), tag.Upsert(resourceTag, resource)}
 
 		if evt.DeltaIn != 0 {
-			tagsWithDir := make([]tag.Mutator, 3)
+			tagsWithDir := make([]tag.Mutator, 0, 3)
 			tagsWithDir = append(tagsWithDir, tag.Insert(directionTag, "inbound"))
 			tagsWithDir = append(tagsWithDir, tags...)
 			stats.RecordWithTags(ctx, tagsWithDir[0:], blockedResources.M(int64(1)))
 		}
 
 		if evt.DeltaOut != 0 {
-			tagsWithDir := make([]tag.Mutator, 3)
+			tagsWithDir := make([]tag.Mutator, 0, 3)
 			tagsWithDir = append(tagsWithDir, tag.Insert(directionTag, "outbound"))
 			tagsWithDir = append(tagsWithDir, tags...)
 			stats.RecordWithTags(ctx, tagsWithDir, blockedResources.M(int64(1)))

--- a/obs/stats_test.go
+++ b/obs/stats_test.go
@@ -2,9 +2,11 @@ package obs_test
 
 import (
 	"testing"
+	"time"
 
 	rcmgr "github.com/libp2p/go-libp2p-resource-manager"
 	"github.com/libp2p/go-libp2p-resource-manager/obs"
+	"go.opencensus.io/stats/view"
 )
 
 func TestTraceReporterStartAndClose(t *testing.T) {
@@ -13,4 +15,25 @@ func TestTraceReporterStartAndClose(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer rcmgr.Close()
+}
+
+func TestConsumeEvent(t *testing.T) {
+	evt := rcmgr.TraceEvt{
+		Type:     rcmgr.TraceBlockAddStreamEvt,
+		Name:     "conn-1",
+		DeltaOut: 1,
+		Time:     time.Now().Format(time.RFC3339Nano),
+	}
+
+	err := view.Register(obs.DefaultViews...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	str, err := obs.NewStatsTraceReporter()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	str.ConsumeEvent(evt)
 }


### PR DESCRIPTION
Fixes a silly mistake that results in a null pointer error since we're creating zero value objects. This happened because I originally was going to set the items in the array, but then decided to use `append` instead. Adds a test for regression too.